### PR TITLE
feat: allow skipping tf subfolders via config file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,9 @@ require (
 	github.com/shurcooL/githubv4 v0.0.0-20220115235240-a14260e6f8a2
 	github.com/spf13/cobra v1.6.0
 	github.com/terraform-linters/tflint v0.35.0
+	golang.org/x/text v0.3.7
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -84,7 +86,6 @@ require (
 	golang.org/x/net v0.0.0-20220403103023-749bd193bc2b // indirect
 	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect
 	golang.org/x/sys v0.0.0-20220405210540-1e041c57c461 // indirect
-	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/api v0.40.0 // indirect

--- a/pkg/terraform/fmt.go
+++ b/pkg/terraform/fmt.go
@@ -10,8 +10,8 @@ import (
 
 func FixFmt(cloneDir string) error {
 	for _, tfDir := range FindAllTfDir(cloneDir) {
-		log.Info().Msgf("Executing action fmt on tfDir: %s", tfDir)
-		tf, err := tfexec.NewTerraform(tfDir, terraformPath)
+		log.Info().Msgf("Executing action fmt on tfDir: %s", tfDir.Path())
+		tf, err := tfexec.NewTerraform(tfDir.Path(), terraformPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
By creating a `.tf-checker` file in a tf subfolder, it will get discarded.