### PR TITLE
feat: ci: support arm64v8 via docker multi-arch

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,10 +21,26 @@ builds:
       - -X main.buildTag={{ .Version }}
 
 dockers:
-  - goos: linux
+  - use: buildx
+    goos: linux
     goarch: amd64
     image_templates:
-      - "ghcr.io/terraform-tools/terraform-checker:{{ .Version }}"
+      - "ghcr.io/terraform-tools/terraform-checker:{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/terraform-tools/terraform-checker:{{ .Version }}-arm64v8"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+
+docker_manifests:
+  - name_template: "ghcr.io/terraform-tools/terraform-checker:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/terraform-tools/terraform-checker:{{ .Version }}-amd64"
+      - "ghcr.io/terraform-tools/terraform-checker:{{ .Version }}-arm64v8"
 
 snapshot:
   name_template: "{{ .FullCommit }}-SNAPSHOT"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,8 @@ dockers:
       - "ghcr.io/terraform-tools/terraform-checker:{{ .Version }}-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--build-arg=TFSWITCH_ARCH=arm64"
+      - "--build-arg=TFLINT_ARCH=arm64"
 
 docker_manifests:
   - name_template: "ghcr.io/terraform-tools/terraform-checker:{{ .Version }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,14 @@ COPY terraform-checker /go/bin/terraform-checker
 RUN apk add curl git openssh unzip
 
 # Simple tfswitch
-RUN curl -Ls https://github.com/terraform-tools/simple-tfswitch/releases/download/0.1.6/simple-tfswitch_0.1.6_Linux_x86_64.tar.gz | tar xzf - -C /usr/local/bin
+ARG TFSWITCH_ARCH=x86_64
+RUN curl -Ls https://github.com/terraform-tools/simple-tfswitch/releases/download/0.1.6/simple-tfswitch_0.1.6_Linux_${TFSWITCH_ARCH}.tar.gz | tar xzf - -C /usr/local/bin
 RUN mv /usr/local/bin/simple-tfswitch /usr/local/bin/terraform
 
 # Tflint
+ARG TFLINT_ARCH=amd64
 ENV TFLINT_VERSION v0.43.0
-RUN wget https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint_linux_amd64.zip -O /tmp/tflint.zip && \
+RUN wget https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint_linux_${TFLINT_ARCH}.zip -O /tmp/tflint.zip && \
     unzip /tmp/tflint.zip -d /bin && \
     rm /tmp/tflint.zip
 


### PR DESCRIPTION
**This PR proposes building docker images for both amd64 and arm64v8,**
as well as creating the mutli-arch manifest that allows for auto-resolution by the container runtime

_( meaning the end-user will still be able to use `docker pull ghcr.io/terraform-tools/terraform-checker:1.3.0`,
and the built image that actually correspond to the user's architecture will be pulled )._