### PR TITLE
fix: enable qemu support for arm64v8 builds via buildx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
       -
         name: Checkout
@@ -24,8 +26,11 @@ jobs:
         with:
           go-version: 1.18
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
When _**not**_ using docker-desktop,
using QEMU as backend for buildx to build images of a different arch **_must_** be opted-in and configured.

Additionally, using the `docker manifest` commands requires explicit opt-in via the `DOCKER_CLI_EXPERIMENTAL` flag
( required for creating the "meta" images that allow for the container runtime to automatically fetch the correct image for the platform ).

An example successful run can be found here : https://github.com/hileef/terraform-checker/actions/runs/3565729136/jobs/5991259090